### PR TITLE
Fix styles for buttons on red slides

### DIFF
--- a/src/styles/slide.css
+++ b/src/styles/slide.css
@@ -33,7 +33,7 @@
       }
     }
 
-    a {
+    a:not(.btn) {
       color: $yellow;
 
       &:hover {


### PR DESCRIPTION
I broke it in #18 and buttons on red slides now also became yellow, together with links.
This PR fixes buttons (see “Read more →” button on the following screenshot).
![image](https://user-images.githubusercontent.com/264400/128040649-693af714-3ef4-4101-b980-edaa8c7a5e0a.png)
