### PR TITLE
fix: top-nav animation fix (safari)

### DIFF
--- a/src/styles/slides/nav.css
+++ b/src/styles/slides/nav.css
@@ -6,7 +6,7 @@
   right: 0;
   z-index: 30;
   display: flex;
-  transition: all 200ms ease-in-out;
+  transition: all .3s ease-in-out;
   justify-content: space-between;
   padding: 60px 60px 0 60px;
   pointer-events: none;
@@ -17,7 +17,6 @@
   }
 
   .is-bubbling & {
-    animation: bubble 200ms backwards ease-in-out;
     top: 0;
     opacity: 1;
   }
@@ -47,8 +46,3 @@
     left: 0;
   }
 }
-
-@keyframes bubble {
-  from {opacity:0; top: -200px;}
-  to {opacity:1;top: 0;}
-  }


### PR DESCRIPTION
The appearance animation did not work correctly in safari 15.4

**Before:**

https://user-images.githubusercontent.com/84858680/159851521-9ab8eaa8-4ac3-4c21-b9d0-853ad602a889.mov

**After:**

https://user-images.githubusercontent.com/84858680/159851446-5735f8c0-e8dc-47e7-9428-4381d792b57b.mov


