### PR TITLE
fix: gears spin animation (safari)

### DIFF
--- a/src/styles/sprite.css
+++ b/src/styles/sprite.css
@@ -30,11 +30,23 @@
 }
 
 @keyframes cog-spin {
-  100% { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes cog-spin-back {
-  100% { transform: rotate(-360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(-360deg);
+  }
 }
 
 @keyframes coin-throw {


### PR DESCRIPTION
Gears did not spin in safari 15.4

**Before:**

https://user-images.githubusercontent.com/84858680/159855844-e6194061-7d55-4f87-8dac-1318b1424564.mov

**After:**

https://user-images.githubusercontent.com/84858680/159855889-7ef8dd5b-6dac-495b-8345-a89d52fe78cb.mov