### PR TITLE
Fix typo in resources-slide.hbs

### DIFF
--- a/src/partials/slides/resources-slide.hbs
+++ b/src/partials/slides/resources-slide.hbs
@@ -141,7 +141,7 @@
           on YouTube.
         </li>
         <li class='list-box__item'>
-          Watch the RailConf 2022 talk
+          Watch the RailsConf 2022 talk
           <a
             class='link list-box__link'
             href='https://www.youtube.com/watch?v=TgpSs2ffJL0'


### PR DESCRIPTION
I noticed it is RailsConf everywhere else, so this seemed like a typo. :)