### PR TITLE
Improve demo chat layout

### DIFF
--- a/src/modules/blocks/demo.scss
+++ b/src/modules/blocks/demo.scss
@@ -56,6 +56,7 @@ $className: 'demo';
     }
 
     &__input {
+      width: 100%;
       max-width: 100%;
       appearance: none;
       border: none;
@@ -75,12 +76,13 @@ $className: 'demo';
       margin: 0 5px 5px 5px;
       color: $fontPrimaryInvertedColor;
       background-color: $accentPrimaryColor;
+      align-self: flex-end;
 
       &_theirs {
         color: $fontPrimaryColor;
         border-color: #dcdcdc;
         background-color: #dcdcdc;
-        align-self: flex-end;
+        align-self: flex-start;
       }
     }
 
@@ -101,7 +103,7 @@ $className: 'demo';
       border-bottom: 1px solid $borderPrimaryColor;
 
       &_offline {
-        & [role=status] {
+        & [role='status'] {
           color: $fontSecondaryColor;
 
           &::before {
@@ -134,13 +136,13 @@ $className: 'demo';
 
     &__status {
       font-size: 0.8rem;
-      color: #48BE00;
+      color: #48be00;
       font-weight: bold;
       text-decoration: none;
       position: relative;
 
       &::before {
-        content: "•";
+        content: '•';
         font-size: 40px;
         position: absolute;
         left: -14px;


### PR DESCRIPTION
Some styles look off in the demo chat of Alice and Bob.

This PR includes following fixes:
- Alice's messages in Bob's screen are too wide (don't depend on message content)
- Input should be 100% width
- Sides where sent messages appear should be inverted — usually "my" messages are on the right.

Before:
<img width="795" height="520" alt="Screenshot 2025-08-28 at 14 21 54" src="https://github.com/user-attachments/assets/861a121e-ac19-425a-bc9e-874e22fea676" />

After:
<img width="898" height="526" alt="Screenshot 2025-08-28 at 14 23 15" src="https://github.com/user-attachments/assets/c930d289-5f0f-456a-9b50-8795f80a0593" />

