### PR TITLE
Tag Plausible events; replace Consulting Typeform with email CTA

### DIFF
--- a/src/compare/nodejs-websocket/index.html
+++ b/src/compare/nodejs-websocket/index.html
@@ -839,8 +839,8 @@ app.publish(<span class='c-str'>'chat:42'</span>, <span class='c-str'>JSON</span
               Self-host the Go binary alongside your Node service, or skip the deploy and start on the free managed tier.
             </p>
             <div class='compare-cta__actions'>
-              <a href='https://docs.anycable.io/guides/serverless' target='_blank' class='button button_size_big' data-ph-capture-attribute-link-id='compare-cta-docs'>Node / JS guide</a>
-              <a href='https://plus.anycable.io/' target='_blank' class='button button_size_big button_variant_outlined' data-ph-capture-attribute-link-id='compare-cta-managed'>Try AnyCable+ free</a>
+              <a href='https://docs.anycable.io/guides/serverless' target='_blank' class='button button_size_big plausible-event-name=Navigation plausible-event-link=compare-cta-docs' data-ph-capture-attribute-link-id='compare-cta-docs'>Node / JS guide</a>
+              <a href='https://plus.anycable.io/' target='_blank' class='button button_size_big button_variant_outlined plausible-event-name=Signup plausible-event-location=compare' data-ph-capture-attribute-link-id='compare-cta-managed'>Try AnyCable+ free</a>
             </div>
           </div>
         </section>

--- a/src/index.html
+++ b/src/index.html
@@ -11,9 +11,7 @@
       </main>
       {{> footer }}
     </div>
-    {{> popup popupClass='try-now-popup'}} {{> popup
-    popupClass='contact-us-popup' popupTitle = 'Contact us'
-    typeformLink='https://form.typeform.com/c/wAHm0sRP'}}
+    {{> popup popupClass='try-now-popup'}}
     <dialog class="company-modal" id="company-modal">
       <button class="company-modal__close" type="button" aria-label="Close"></button>
       <div class="company-modal__content">

--- a/src/js/components/popups-show-hide.ts
+++ b/src/js/components/popups-show-hide.ts
@@ -1,14 +1,11 @@
 import Popup from './Popup';
 
 const tryNowPopup = new Popup('.try-now-popup');
-const contactUsPopup = new Popup('.contact-us-popup');
 
 const signUpBtn = document.querySelector('.sign-up-btn');
 const tryNowBtns = document.querySelectorAll('.try-now-btn');
-const contactUsBtn = document.querySelector('.contact-us-btn');
 
 tryNowPopup.init(); //prevents flickering while loading
-contactUsPopup.init(); //prevents flickering while loading
 
 signUpBtn?.addEventListener('click', () => {
   tryNowPopup.open();
@@ -19,7 +16,3 @@ tryNowBtns.forEach(btn =>
     tryNowPopup.open();
   })
 );
-
-contactUsBtn?.addEventListener('click', () => {
-  contactUsPopup.open();
-});

--- a/src/partials/analytics.hbs
+++ b/src/partials/analytics.hbs
@@ -3,4 +3,11 @@
   <script> !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init('phc_fc9VFWdFAAm5gSlCodHq93iaxxnTTKbjOwsWgAS1FMP',{api_host:'https://app.posthog.com'})</script>
   <!-- End Posthog -->
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-sk7JDKlDe3CHAdBbykSWN.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
+  <!-- End Plausible -->
 {{/if}}

--- a/src/partials/blog_nav.hbs
+++ b/src/partials/blog_nav.hbs
@@ -4,6 +4,6 @@
       <span class='blog-header__link-icon'>
         {{inline 'images/arrow-left.svg'}}
       </span>{{coalesce backLinkLabel 'Other Posts'}}</a>
-    <button class='button try-now-btn'>Try it now</button>
+    <button class='button try-now-btn plausible-event-name=Signup plausible-event-location=blog'>Try it now</button>
   </nav>
 </header>

--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -7,7 +7,7 @@
           <li class='footer__list-item'>
             <a
               href='https://github.com/anycable/anycable'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-github'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-github'
             >GitHub</a>
@@ -15,7 +15,7 @@
           <li class='footer__list-item'>
             <a
               href='https://rubygems.org/gems/anycable'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-rubygems'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-rubygems'
             >RubyGems</a>
@@ -23,7 +23,7 @@
           <li class='footer__list-item'>
             <a
               href='https://hub.docker.com/u/anycable'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-docker'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-docker'
             >DockerHub</a>
@@ -38,7 +38,7 @@
           <li class='footer__list-item'>
             <a
               href='https://docs.anycable.io/'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-docs'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-docs'
             >Documentation</a>
@@ -46,25 +46,25 @@
           <li class='footer__list-item'>
             <a
               href='https://github.com/anycable/anycable_rails_demo'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-demo'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-demo'
             >Demo App</a>
           </li>
           <li class='footer__list-item'>
-            <a href='https://blog.anycable.io' class='link' target='_blank' data-ph-capture-attribute-link-id='footer-blog'>Blog</a>
+            <a href='https://blog.anycable.io' class='link plausible-event-name=Navigation plausible-event-link=footer-blog' target='_blank' data-ph-capture-attribute-link-id='footer-blog'>Blog</a>
           </li>
           <li class='footer__list-item'>
             <a
               href='/compare/nodejs-websocket'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-compare'
               data-ph-capture-attribute-link-id='footer-compare'
             >Comparisons</a>
           </li>
           <li class='footer__list-item'>
             <a
               href='https://www.youtube.com/playlist?list=PLAgBW0XUpyOVFnpoS6FKDszd8WEvXzg-A'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-screencasts'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-screencasts'
             >Screencasts
@@ -80,7 +80,7 @@
           <li class='footer__list-item'>
             <a
               href='https://anycable.substack.com/'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-substack'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-substack'
             >Newsletter</a>
@@ -88,7 +88,7 @@
           <li class='footer__list-item'>
             <a
               href='https://twitter.com/any_cable'
-              class='link'
+              class='link plausible-event-name=Navigation plausible-event-link=footer-twitter'
               target='_blank'
               data-ph-capture-attribute-link-id='footer-twitter'
             >Twitter</a>
@@ -100,12 +100,12 @@
       <p class='footer__legal footer__legal_type_copyright'>
         {{currentYear}}
         <a
-          class='link'
+          class='link plausible-event-name=Navigation plausible-event-link=footer-twitter-palkan'
           href='https://twitter.com/palkan_tula'
           target='_blank'
           data-ph-capture-attribute-link-id='footer-twitter-palkan'
         >Vladimir Dementyev&nbsp;</a>&amp;&nbsp;<a
-          class='link'
+          class='link plausible-event-name=Navigation plausible-event-link=footer-evlms'
           href='https://evilmartians.com/'
           data-ph-capture-attribute-link-id='footer-evlms'
         >Evil Martians</a>
@@ -113,7 +113,7 @@
       <p class='footer__legal'>
         Released under the
         <a
-          class='link'
+          class='link plausible-event-name=Navigation plausible-event-link=footer-mit'
           href='https://opensource.org/licenses/MIT'
           target='_blank'
           data-ph-capture-attribute-link-id='footer-mit'
@@ -122,7 +122,7 @@
       <p class='footer__legal'>
         Website by
         <a
-          class='link'
+          class='link plausible-event-name=Navigation plausible-event-link=footer-twitter-antiflasher'
           href='https://twitter.com/antiflasher'
           data-ph-capture-attribute-link-id='footer-twitter-antiflasher'
           target='_blank'
@@ -131,7 +131,7 @@
       <p class='footer__legal'>
         Drop us a line:
         <a
-          class='link'
+          class='link plausible-event-name=Contact plausible-event-location=footer'
           href='mailto:anycable@evilmartians.com'
           target='_blank'
         >anycable@evilmartians.com</a>

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -3,19 +3,19 @@
     <div class='header__left'>
       <a href="/" class='header__logo'>AnyCable</a>
       <div class='header__links no-mobile'>
-        <a href="/#features" class="header__link" data-ph-capture-attribute-link-id="nav-features">Features</a>
-        <a href="/#customers" class="header__link" data-ph-capture-attribute-link-id="nav-customers">Customers</a>
-        <a href="/#pricing" class="header__link" data-ph-capture-attribute-link-id="nav-pricing">Pricing</a>
-        <a href="https://docs.anycable.io" target="_blank" class="header__link" data-ph-capture-attribute-link-id="nav-docs">Docs</a>
-        <a href="/#resources" class="header__link" data-ph-capture-attribute-link-id="nav-resources">Resources</a>
+        <a href="/#features" class="header__link plausible-event-name=Navigation plausible-event-link=nav-features" data-ph-capture-attribute-link-id="nav-features">Features</a>
+        <a href="/#customers" class="header__link plausible-event-name=Navigation plausible-event-link=nav-customers" data-ph-capture-attribute-link-id="nav-customers">Customers</a>
+        <a href="/#pricing" class="header__link plausible-event-name=Navigation plausible-event-link=nav-pricing" data-ph-capture-attribute-link-id="nav-pricing">Pricing</a>
+        <a href="https://docs.anycable.io" target="_blank" class="header__link plausible-event-name=Navigation plausible-event-link=nav-docs" data-ph-capture-attribute-link-id="nav-docs">Docs</a>
+        <a href="/#resources" class="header__link plausible-event-name=Navigation plausible-event-link=nav-resources" data-ph-capture-attribute-link-id="nav-resources">Resources</a>
       </div>
     </div>
     <div class='header__right'>
-      <a class='header__stars' href="https://github.com/anycable/anycable" target="_blank" data-ph-capture-attribute-link-id="nav-github">
+      <a class='header__stars plausible-event-name=Navigation plausible-event-link=nav-github' href="https://github.com/anycable/anycable" target="_blank" data-ph-capture-attribute-link-id="nav-github">
         {{inline 'images/github.svg'}}
         <span class='header__stars__count' id="gh-stars-counter">1.9K</span>
       </a>
-      <a href="https://plus.anycable.io/pro" target="_blank" class="button" data-ph-capture-attribute-link-id='go-pro'>Sign up</a>
+      <a href="https://plus.anycable.io/pro" target="_blank" class="button plausible-event-name=Signup plausible-event-location=header" data-ph-capture-attribute-link-id='go-pro'>Sign up</a>
     </div>
   </nav>
 </header>

--- a/src/partials/slides/main-slide.hbs
+++ b/src/partials/slides/main-slide.hbs
@@ -23,11 +23,11 @@
             <span class='try-now__caption try-now__caption_bolded'>free trial</span>
             of SaaS, or on premise Pro
           </p>
-          <a href="https://plus.anycable.io/pro" target="_blank" class='button button_size_big try-now__button' data-ph-capture-attribute-link-id='try-pro-now'>
+          <a href="https://plus.anycable.io/pro" target="_blank" class='button button_size_big try-now__button plausible-event-name=Signup plausible-event-location=hero' data-ph-capture-attribute-link-id='try-pro-now'>
             Sign up
           </a>
         </div>
-        <button class='main-slide__learn-more-btn' data-ph-capture-attribute-link-id='learn-more'></button>
+        <button class='main-slide__learn-more-btn plausible-event-name=Navigation plausible-event-link=learn-more' data-ph-capture-attribute-link-id='learn-more'></button>
       </div>
     </div>
   </div>

--- a/src/partials/slides/plans-slide.hbs
+++ b/src/partials/slides/plans-slide.hbs
@@ -106,9 +106,9 @@
             class='plan-card__contact-text'
           >anycable@evilmartians.com</span>
         </p>
-        <button class='button contact-us-btn' data-ph-capture-attribute-link-id='plan-custom'>
+        <a href='mailto:anycable@evilmartians.com' class='button plausible-event-name=Contact plausible-event-location=consulting' data-ph-capture-attribute-link-id='plan-custom'>
           Contact us
-        </button>
+        </a>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
Follow-up to #56. Adds Plausible tagged events on key user actions and removes the Consulting Typeform.

## Events (class-based, no JS)
- **Navigation** (`link` prop) on header nav links, GitHub, the hero "Learn more" button, and all footer links.
- **Signup** (`location` prop: `header` / `hero`) on both Sign up CTAs.
- **Contact** (`location` prop: `consulting` / `footer`) on the Consulting CTA and the footer email link.

The taxonomy mirrors the existing PostHog `link-id` attributes, grouped into 3 goals so the dashboard stays clean (break down by the `link` / `location` property).

## Consulting Typeform removed
- The Consulting "Contact us" button now links to `mailto:anycable@evilmartians.com` instead of opening a Typeform popup.
- Removed the orphaned `contact-us-popup` include and its JS wiring. The unrelated try-now popup (used by the blog "Try it now" button) is untouched.

## Dashboard setup needed
Create matching goals in Plausible: **Signup**, **Navigation**, **Contact**. Tagged events only show once their goal exists.

Verified with a production build: all event classes render and the Consulting CTA is a mailto link.