### PR TITLE
Fix Jane customer figure ($100M+ raised was incorrect)

### DIFF
--- a/src/partials/slides/cases-slide.hbs
+++ b/src/partials/slides/cases-slide.hbs
@@ -28,7 +28,7 @@
           </div>
           <div class="cases-slide__company-card" data-ph-capture-attribute-link-id="customer-jane"
             data-url="https://jane.app"
-            data-detail="Jane is a practice management platform for allied health clinics across Canada. AnyCable powers real-time scheduling updates and notifications for thousands of clinics. $100M+ raised.">
+            data-detail="Jane is a practice management platform for allied health clinics across Canada. AnyCable powers real-time scheduling updates and notifications for thousands of clinics. $1.8B valuation (2025).">
             <span class="cases-slide__company-name">Jane</span>
             <span class="cases-slide__company-desc">Practice management for allied health clinics</span>
           </div>


### PR DESCRIPTION
## What

The Jane customer card stated **\$100M+ raised**, which is incorrect. Jane Software has raised **under \$10M in primary capital** (founded 2012, largely bootstrapped). The "\$100M" appears to have conflated annual revenue / secondary-market activity with funding raised.

Replaced with the most recent well-sourced figure: **\$1.8B valuation (2025)**, from the TCV-led ~\$500M secondary financing.

Sources:
- [The Globe and Mail](https://www.theglobeandmail.com/business/article-jane-software-hits-18-billion-valuation-as-tcv-leads-500-million/)
- [Fasken](https://www.fasken.com/en/experience/2025/08/jane-software-valuation-secondary-financing-round)

## Scope

One line in `src/partials/slides/cases-slide.hbs` (the customers slide `data-detail` text).

## Note on the uWS jitter number (not changed)

A separate review flagged that the Node.js compare page shows uWS jitter delivery at 87.03% while a raw result file shows 73.19%. On investigation this is **not** a page error: 87.03% is corroborated by the bench repo's `README.md` and `docs/methodology.md`, and the 73.19% file carries the signature of a saturated bench-runner (p99 11.9s vs 1.7s), which the methodology explicitly warns deflates delivery. Left the page as-is; the stray result file should be cleaned up in the bench repo instead.