### PR TITLE
AnyCable Pro instance-based pricing tiers

### DIFF
--- a/src/eula/eula.pug
+++ b/src/eula/eula.pug
@@ -1,96 +1,78 @@
 h1 AnyCable Pro End-User License Agreement
 
+p.eula-effective Effective date: July 7, 2026
+
 p.
   This software end-user license agreement ("EULA") is a legal agreement ("Agreement") between you (the customer, either
-  as an individual or, if purchased or otherwise acquired by or for an entity, as an entity) and Evil Martians Inc.
-  ("Licensor"). Read it carefully before completing the installation process and using AnyCable Pro and all upgrades made
-  available to you ("Software"). It provides a license to use the Software and contains warranty information and liability
-  disclaimers. By installing and using the Software, you are confirming your acceptance of the Software and agreeing to
-  become bound by the terms of this Agreement.
+  as an individual or, if purchased or otherwise acquired by or for an entity, as an entity) and Evil Martians Inc., a
+  Delaware corporation with its principal place of business at 77 Sands St, Brooklyn, New York 11201 ("Licensor"). Read it
+  carefully before completing the installation process and using AnyCable Pro and all upgrades made available to you
+  ("Software"). It provides a license to use the Software and contains warranty information and liability disclaimers. By
+  installing and using the Software, you are confirming your acceptance of the Software and agreeing to become bound by the
+  terms of this Agreement.
+
+h2 Definitions.
+
+p.
+  "AnyCable Pro" or "Software" means the AnyCable Pro WebSocket server distributed by Licensor, together with any updates
+  provided under an active subscription. It does not include the open-source AnyCable components, which are governed by
+  their own licenses.
+
+p.
+  "Instance" means one running process of the AnyCable Pro WebSocket server in a Production environment. Each replica,
+  container, pod, or virtual machine running the Software is a separate Instance. Multiple Software processes on one host
+  are multiple Instances. Customer's application, web, and RPC processes are not Instances.
+
+p.
+  "Production" means any environment serving live end-user or business traffic. Development, testing, staging,
+  continuous-integration, and preview environments are not Production.
+
+p.
+  "Steady-State Peak" means the greatest number of Instances running concurrently for a sustained period during Customer's
+  normal operation. Transient increases from autoscaling, rolling deployment, failover, or load testing are excluded.
+
+p.
+  "Tier" means the Startup, Business, or Scale subscription level identified in the Order Form, each corresponding to a
+  maximum Steady-State Peak number of Instances.
 
 h2 1. License.
 
 p.
-  Subject to payment of the applicable fees and compliance with this EULA, Licensor grants you a limited,
-  non-exclusive and non-transferable license to use the rights for the Software, without the right to grant sublicenses,
-  subject to the terms and conditions in this Agreement. The Software is licensed, not sold.
+  Subject to the terms of this Agreement and payment of applicable fees, Licensor grants Customer a limited,
+  non-exclusive, non-transferable, worldwide license during the subscription term, without the right to grant
+  sublicenses, to install and run the Software in Production up to the Steady-State Peak Instance count of Customer's Tier,
+  and in any number of non-Production environments. Customer may run the Software on any infrastructure Customer controls,
+  including containerized, virtualized, cloud, and air-gapped environments. The Software is licensed, not sold.
 
 h2 2. Delivery.
 
 p.nested.
   (a) In order to use the Software under this Agreement, you shall receive the Installation Instructions and all other
-  necessary installation information that will be send to your email account at the time of purchase, in accordance with
-  the scope of use and other terms specified for each type of Software and as set forth in this Section 3 (License Types).
+  necessary installation information that will be sent to your email account at the time of purchase, in accordance with
+  the scope of use and other terms specified for each type of Software.
 
 p.nested.
   (b) All Software and license documentation shall be delivered by electronic means unless otherwise specified in the
   applicable invoice or at the time of purchase. Software shall be deemed delivered when it is made available for download
   by you.
 
+p.nested.
+  (c) Licensor grants access to the Software through a license-controlled distribution channel (container registry and/or
+  package repository). Customer's access credentials are tied to Customer's active subscription and may not be shared
+  outside Customer's organization. Licensor may issue an offline license file for air-gapped environments on request.
+
 h2 3. License Types.
 
 p.nested.
-  (a) Standard Commercial Use License. If you purchased a Standard Commercial Use License, you may use the Software solely
-  for your internal operations, as well as translate or incorporate the Software into other software. However, under no
-  circumstances may you sell or use the Software as part of a product or service that competes with the Software itself.
-  For example, you may not provide the Software “as a service” for integration into others’ software applications, or an
-  enhanced version of the Software offering performance or general-purpose functional improvements. A product or service
-  may compete even if it provides its functionality via a different kind of interface (such as a service, library, or
-  plug-in), even if it is ported to a different platform or programming language, and even if it is provided free of
-  charge.
+  (a) Standard Commercial Use License. If you purchased a Standard Commercial Use License, you may use the Software for
+  your internal operations, including translating or incorporating the Software into other software for that purpose. You
+  may not sell, sublicense, or redistribute the Software, or provide it to third parties as a product or service, except
+  as expressly permitted in this Agreement (see Section 5).
 
 p.nested.
-  (b) Extended Commercial Use License. If you purchased an Extended Commercial Use License, you may use the Software for
-  your internal operations and commercial activities, as well as translate or incorporate the Software into other
-  Software. Also, you are entitled to use the Software as a part of a product or service that provides similar
-  functionality to the Software itself.
-
-p.nested.
-  (c) Instances and Environments. An "Instance" means one running process of the Software in a Production environment.
-  Each replica, container, pod, or virtual machine running the Software is a separate Instance. Multiple Software
-  processes running on the same host are counted as multiple Instances. Your application, web, and remote procedure call
-  (RPC) processes are not Instances. "Production" means any environment serving live end-user or business traffic;
-  development, testing, staging, continuous-integration, and preview environments are not Production and are not counted.
-  Your "Steady-State Peak" means the greatest number of Instances running concurrently for a sustained period during your
-  normal operation; transient increases caused by autoscaling, rolling deployment, failover, or load testing are excluded.
-
-p.nested.
-  (d) Subscription Tiers. Your license specifies a subscription tier in the applicable invoice or at the time of
-  purchase, which determines the maximum number of Production Instances you may run. You may run the Software in any
-  number of non-Production environments regardless of tier. The tiers are:
-
-p.nested-2.
-  (i) Startup: up to five (5) Production Instances;
-
-p.nested-2.
-  (ii) Business: up to twenty (20) Production Instances;
-
-p.nested-2.
-  (iii) Scale: more than twenty (20) Production Instances, as agreed in the applicable invoice, together with priority
-  support and the critical-patch response target described in Section 7(d);
-
-p.nested-2.
-  (iv) Enterprise: as described in subsection (g) below.
-
-p.nested.
-  (e) Good-Faith Reporting; No Usage Monitoring. The Software does not meter usage, count connections, transmit
-  telemetry, or contact Licensor during operation, and it does not disable or degrade itself if your Steady-State Peak
-  exceeds your tier. Your compliance with your tier is based on good-faith self-reporting of your Steady-State Peak at the
-  time of purchase and at each renewal. Licensor does not monitor or audit your infrastructure and relies on your
-  declaration.
-
-p.nested.
-  (f) Tier at Renewal. If your Steady-State Peak grows beyond your current tier during a term, you may continue to run the
-  Software for the remainder of that term at your current tier and price, and you agree to move to the tier matching your
-  Steady-State Peak at your next renewal.
-
-p.nested.
-  (g) Enterprise and Source Access. The Startup, Business, and Scale tiers grant the right to run the Software in object
-  (binary) form only. Access to the Software's source code, and the right to modify it for your internal operations, are
-  available only under the Enterprise tier or a separate source license, on terms set out in the applicable invoice.
-  Except under such a license, the rights described in Section 4(b) (Modifications) apply only to the extent the
-  Software's source code is otherwise made available to you, and you shall not decompile, disassemble, or reverse engineer
-  the Software.
+  (b) Enterprise License. Access to and modification of the Software's source code require a separate Enterprise license,
+  which may be added to any Tier and is identified in the Order Form. Except under an active Enterprise license, Customer
+  may not access, decompile, reverse engineer, or modify the Software's source code.
 
 h2 4. Permitted Uses.
 
@@ -99,7 +81,10 @@ p.nested.
   copy must reproduce all copyright and other proprietary rights notices on or in the Software.
 
 p.nested.
-  (b) Modifications. You are entitled to create Modifications of the original Software. "Modification" means:
+  (b) Modifications. Access to and modification of the Software's source code require a separate Enterprise license (see
+  Section 3(b)). Except under an active Enterprise license, Customer may not decompile, reverse engineer, or modify the
+  Software. Where Customer holds an active Enterprise license, Customer is entitled to create Modifications of the
+  original Software, and "Modification" means:
 
 p.nested-2.
   (i) any addition to or deletion from the contents of a file included in the original Software or previous Modifications
@@ -177,10 +162,10 @@ p.nested.
   (c) Internet-based support system is generally available by email: anycable@evilmartians.com.
 
 p.nested.
-  (d) Critical Patches (Scale and Enterprise tiers). For the Scale and Enterprise tiers, Licensor will use commercially
-  reasonable efforts to provide an initial response to reports of critical defects or security issues within forty-eight
-  (48) hours. This is a response-time target and not a guarantee of resolution, workaround, or fix within any particular
-  period of time.
+  (d) Critical Patches (Scale and Enterprise). For the Scale Tier and under an active Enterprise license, Licensor will
+  use commercially reasonable efforts to provide an initial response to reports of critical defects or security issues
+  within forty-eight (48) hours. This is a response-time target and not a guarantee of resolution, workaround, or fix
+  within any particular period of time.
 
 h2 8. Ownership.
 
@@ -208,7 +193,8 @@ p.nested-2.
   (i) fails to cure any material breach of this Agreement within fifteen (15) working days after written notice of such
   breach, provided that Licensor may terminate this Agreement immediately upon any breach of Section 5 (Restricted Uses)
   or if you exceed any other restrictions contained in Section 3 (License Types), unless otherwise specified in this
-  Agreement;
+  Agreement. For clarity, Customer's Steady-State Peak exceeding its Tier is not a breach for purposes of this Section and
+  is governed solely by Section 15 (Instance Tiers, Compliance, and Renewal);
 
 p.nested-2.
   (ii) ceases operation without a successor; or
@@ -318,3 +304,31 @@ p.nested.
 p.nested.
   (i) Contact Information. If you have any questions about this EULA, or if you want to contact Licensor for any reason,
   please direct correspondence to anycable@evilmartians.com.
+
+p.nested.
+  (j) Publicity. Licensor may display Customer's name and logo on Licensor's website (https://anycable.io) to identify
+  Customer as a user of the Software, unless the parties agree otherwise in writing. Licensor will remove Customer's name
+  and logo within a reasonable time following Customer's written request.
+
+h2 15. Instance Tiers, Compliance, and Renewal.
+
+p.nested.
+  (a) Tier compliance. Customer selects a Tier in the Order Form based on its Steady-State Peak number of Instances, and
+  keeps its Production usage within that Tier. If Customer's Steady-State Peak grows beyond its Tier, Customer will move to
+  the appropriate Tier and pay the applicable fees.
+
+p.nested.
+  (b) Upgrading. If Customer's Steady-State Peak grows beyond its Tier, Customer will upgrade by contacting Licensor at
+  anycable@evilmartians.com. The higher Tier and its fee apply from the date of the change, prorated for the remainder of
+  the current billing period.
+
+p.nested.
+  (c) No runtime restriction. The Software does not disable or degrade itself if Customer exceeds its Tier.
+
+p.nested.
+  (d) Transient usage. Brief increases from autoscaling, rolling deployment, failover, or load testing do not count toward
+  Customer's Tier.
+
+p.nested.
+  (e) Renewal. This Agreement does not automatically renew. Any renewal requires a new Order Form executed by both
+  parties, priced at Licensor's then-current rates for Customer's Tier.

--- a/src/eula/eula.pug
+++ b/src/eula/eula.pug
@@ -45,6 +45,53 @@ p.nested.
   Software. Also, you are entitled to use the Software as a part of a product or service that provides similar
   functionality to the Software itself.
 
+p.nested.
+  (c) Instances and Environments. An "Instance" means one running process of the Software in a Production environment.
+  Each replica, container, pod, or virtual machine running the Software is a separate Instance. Multiple Software
+  processes running on the same host are counted as multiple Instances. Your application, web, and remote procedure call
+  (RPC) processes are not Instances. "Production" means any environment serving live end-user or business traffic;
+  development, testing, staging, continuous-integration, and preview environments are not Production and are not counted.
+  Your "Steady-State Peak" means the greatest number of Instances running concurrently for a sustained period during your
+  normal operation; transient increases caused by autoscaling, rolling deployment, failover, or load testing are excluded.
+
+p.nested.
+  (d) Subscription Tiers. Your license specifies a subscription tier in the applicable invoice or at the time of
+  purchase, which determines the maximum number of Production Instances you may run. You may run the Software in any
+  number of non-Production environments regardless of tier. The tiers are:
+
+p.nested-2.
+  (i) Startup: up to five (5) Production Instances;
+
+p.nested-2.
+  (ii) Business: up to twenty (20) Production Instances;
+
+p.nested-2.
+  (iii) Scale: more than twenty (20) Production Instances, as agreed in the applicable invoice, together with priority
+  support and the critical-patch response target described in Section 7(d);
+
+p.nested-2.
+  (iv) Enterprise: as described in subsection (g) below.
+
+p.nested.
+  (e) Good-Faith Reporting; No Usage Monitoring. The Software does not meter usage, count connections, transmit
+  telemetry, or contact Licensor during operation, and it does not disable or degrade itself if your Steady-State Peak
+  exceeds your tier. Your compliance with your tier is based on good-faith self-reporting of your Steady-State Peak at the
+  time of purchase and at each renewal. Licensor does not monitor or audit your infrastructure and relies on your
+  declaration.
+
+p.nested.
+  (f) Tier at Renewal. If your Steady-State Peak grows beyond your current tier during a term, you may continue to run the
+  Software for the remainder of that term at your current tier and price, and you agree to move to the tier matching your
+  Steady-State Peak at your next renewal.
+
+p.nested.
+  (g) Enterprise and Source Access. The Startup, Business, and Scale tiers grant the right to run the Software in object
+  (binary) form only. Access to the Software's source code, and the right to modify it for your internal operations, are
+  available only under the Enterprise tier or a separate source license, on terms set out in the applicable invoice.
+  Except under such a license, the rights described in Section 4(b) (Modifications) apply only to the extent the
+  Software's source code is otherwise made available to you, and you shall not decompile, disassemble, or reverse engineer
+  the Software.
+
 h2 4. Permitted Uses.
 
 p.nested.
@@ -128,6 +175,12 @@ p.nested.
 
 p.nested.
   (c) Internet-based support system is generally available by email: anycable@evilmartians.com.
+
+p.nested.
+  (d) Critical Patches (Scale and Enterprise tiers). For the Scale and Enterprise tiers, Licensor will use commercially
+  reasonable efforts to provide an initial response to reports of critical defects or security issues within forty-eight
+  (48) hours. This is a response-time target and not a guarantee of resolution, workaround, or fix within any particular
+  period of time.
 
 h2 8. Ownership.
 

--- a/src/modules/blocks/plan-card.scss
+++ b/src/modules/blocks/plan-card.scss
@@ -86,6 +86,66 @@ $className: 'plan-card';
     margin-left: 25px;
   }
 
+  &__tiers {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__tiers-caption {
+    font-weight: 700;
+  }
+
+  &__tier-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  &__tier {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'name price'
+      'limit price';
+    align-items: center;
+    column-gap: 12px;
+    padding: 10px 14px;
+    background-color: rgba(255, 255, 255, 0.12);
+    color: $fontPrimaryInvertedColor;
+  }
+
+  &__tier-name {
+    grid-area: name;
+    font-size: 17px;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+
+  &__tier-limit {
+    grid-area: limit;
+    font-size: 13px;
+    line-height: 1.3;
+    opacity: 0.8;
+  }
+
+  &__tier-price {
+    grid-area: price;
+    justify-self: end;
+    text-align: right;
+    font-size: 17px;
+    font-weight: 700;
+    white-space: nowrap;
+
+    span {
+      font-size: 12px;
+      font-weight: 400;
+      opacity: 0.8;
+    }
+  }
+
   &__action-wrapper {
     display: flex;
     flex-direction: column;

--- a/src/partials/slides/plans-slide.hbs
+++ b/src/partials/slides/plans-slide.hbs
@@ -50,16 +50,36 @@
           <li>Dedicated Slack-based support</li>
         </ul>
       </div>
+      <div class='plan-card__tiers'>
+        <p class='plan-card__text plan-card__text_inverted plan-card__tiers-caption'>
+          Priced by production instances:
+        </p>
+        <ul class='plan-card__tier-list'>
+          <li class='plan-card__tier'>
+            <span class='plan-card__tier-name'>Startup</span>
+            <span class='plan-card__tier-limit'>up to 5 instances</span>
+            <span class='plan-card__tier-price'>$1,490<span>/yr</span></span>
+          </li>
+          <li class='plan-card__tier'>
+            <span class='plan-card__tier-name'>Business</span>
+            <span class='plan-card__tier-limit'>up to 20 instances</span>
+            <span class='plan-card__tier-price'>$4,900<span>/yr</span></span>
+          </li>
+          <li class='plan-card__tier'>
+            <span class='plan-card__tier-name'>Scale</span>
+            <span class='plan-card__tier-limit'>20+ instances, priority support, 48h&nbsp;SLA</span>
+            <span class='plan-card__tier-price'>from $9,000<span>/yr</span></span>
+          </li>
+          <li class='plan-card__tier'>
+            <span class='plan-card__tier-name'>Enterprise</span>
+            <span class='plan-card__tier-limit'>source access &amp; customization</span>
+            <span class='plan-card__tier-price'>Custom</span>
+          </li>
+        </ul>
+      </div>
       <div class='plan-card__action-wrapper'>
         <p class='plan-card__text plan-card__text_inverted'>
-          <span
-            class='plan-card__text-accent plan-card__text-accent_type_big'
-          >$1490</span>
-          per year
-          <br/>
-          Unlimited&nbsp;instances
-          <br/>
-          Free 2-month trial
+          Free 2-month trial. No metering, no telemetry.
         </p>
         <a href="https://plus.anycable.io/pro" target="_blank" class='button button_inverted' data-ph-capture-attribute-link-id='plan-basic'>
           Sign up


### PR DESCRIPTION
Introduces four Pro tiers priced by production instances (Startup / Business / Scale / Enterprise), replacing the flat \$1,490 "unlimited instances" plan.

- **Pricing page:** Pro card now shows the tier ladder (Startup \$1,490, Business \$4,900, Scale from \$9,000, Enterprise custom).
- **EULA:** adds Instance/Production/Steady-State-Peak definitions, tier limits, honor-system (no metering/telemetry) clause, renewal true-up, binary-vs-source split, and a 48h critical-patch SLA for Scale/Enterprise.

⚠️ EULA changes need legal review before merge.